### PR TITLE
Compile-time definition of MGDBDownloader behaviour

### DIFF
--- a/Addons (Optional)/MGDB Downloader/MGDBDownloader/MGDBDownloader.Designer.cs
+++ b/Addons (Optional)/MGDB Downloader/MGDBDownloader/MGDBDownloader.Designer.cs
@@ -5,6 +5,9 @@ namespace PKHeX.WinForms
     {
         public System.Windows.Forms.ToolStripMenuItem EnableMGDBDownloader(System.ComponentModel.ComponentResourceManager resources, bool LatestCommit = false)
         {
+#if LATESTCOMMIT
+            LatestCommit = true;
+#endif
             this.Menu_MGDBDownloader = new System.Windows.Forms.ToolStripMenuItem();
             this.Menu_MGDBDownloader.Image = ((System.Drawing.Image)(resources.GetObject("Menu_ShowdownImportPKM.Image")));
             this.Menu_MGDBDownloader.Name = "Menu_MGDBDownloader";

--- a/build-mod.py
+++ b/build-mod.py
@@ -4,6 +4,7 @@ import re
 import os
 import sys
 
+
 def getopts(argv):
     opts = {}  # Empty dictionary to store key-value pairs.
     while argv:  # While there are arguments left to parse...
@@ -11,6 +12,7 @@ def getopts(argv):
             opts[argv[0]] = argv[1]  # Add key and value to the dictionary.
         argv = argv[1:]  # Reduce the argument list by copying it starting from index 1.
     return opts
+
 
 cmdargs = getopts(sys.argv)
 latestCommit = False


### PR DESCRIPTION
This allows greater flexibility by allowing compiler commandline arguments: https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/define-compiler-option.

AppVeyor won't be taking advantage of this feature yet.